### PR TITLE
Fixed URL pointing to example.sh in 'tutorials' directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ __Requirements__: GPU with CUDA 10+ enabled, [requirements.txt](https://github.c
 </table>
 
 ## TL;DR Quick example
-Run [`sh example.sh`](https://github.com/spaceml-org/Self-Supervised-Learner/blob/main/example.sh) to see the tool in action on the [UC Merced land use dataset](http://weegee.vision.ucmerced.edu/datasets/landuse.html).
+Run [`sh example.sh`](https://github.com/spaceml-org/Self-Supervised-Learner/blob/main/tutorials/example.sh) to see the tool in action on the [UC Merced land use dataset](http://weegee.vision.ucmerced.edu/datasets/landuse.html).
 
 ## Arguments to train.py
 You use train.py to train an SSL model and classifier. There are multiple arguments available for you to use: 


### PR DESCRIPTION
The URL to example.sh in ReadMe file had not been updated. I have changed it to point to https://github.com/spaceml-org/Self-Supervised-Learner/blob/main/tutorials/example.sh